### PR TITLE
move REPOBASE to /home/cephgit to deal with systemd PrivateTmp=true

### DIFF
--- a/gitserver.py
+++ b/gitserver.py
@@ -13,7 +13,7 @@ import subprocess
 
 
 # should contain *.git bare repos
-REPOBASE = "/var/tmp/git"
+REPOBASE = "/home/cephgit/gitserver/git"
 JSONHDR = {"content-type" : "application/json"}
 
 def run_command(cmd, repodir):


### PR DESCRIPTION
apache under systemd can run with PrivateTmp=true, meaning that both
/tmp and /var/tmp are namespaced to a private place.  REPOBASE needs
to exist independently of the process, however.

Signed-off-by: Dan Mick <dan.mick@redhat.com>